### PR TITLE
get-involved links to devcenter repo w/notes re filing issues #199

### DIFF
--- a/lib/en/get-involved.adoc
+++ b/lib/en/get-involved.adoc
@@ -50,3 +50,6 @@ Your feedback drives our design process. Your votes count! Let us know what you 
 
 [.lead]
 link:https://openshift.uservoice.com/forums/258655-ideas[-> Vote on Features]
+
+== Developer Center
+If you've discovered a documentation error on this site, or if you have ideas for content updates or improvements, please link:https://github.com/openshift/devcenter/issues[file an issue to let us know].


### PR DESCRIPTION
DO NOT MERGE (until the repo is made public)

This change introduces a public link to the devcenter issues page, which is currently private.
