### PR TITLE
Fix indentation in flask doc

### DIFF
--- a/lib/en/python-flask.adoc
+++ b/lib/en/python-flask.adoc
@@ -75,8 +75,8 @@ app = Flask(__name__)
 def hello_world():
     return 'Hello World!'
 
-    if __name__ == '__main__':
-        app.run()
+if __name__ == '__main__':
+    app.run()
 ----
 
 link:#top[Back to Top]


### PR DESCRIPTION
We must check for __main__ in global scope, not in a function.