### PR TITLE
[small typo] Fix typo in variable name

### DIFF
--- a/lib/en/node-js-project-structure.adoc
+++ b/lib/en/node-js-project-structure.adoc
@@ -35,7 +35,7 @@ var server_port = process.env.OPENSHIFT_NODEJS_PORT || 8080
 var server_ip_address = process.env.OPENSHIFT_NODEJS_IP || '127.0.0.1'
 
 server.listen(server_port, server_ip_address, function(){
-  console.log("Listening on " + server_ip_address + ", server_port " + port)
+  console.log("Listening on " + server_ip_address + ", server_port " + server_port)
 });
 ----
 


### PR DESCRIPTION
node-js-project-structure.adoc: Fix typo in variable name