### PR TITLE
Minor improvement to the PHP marker file.

### DIFF
--- a/lib/en/php-markers.adoc
+++ b/lib/en/php-markers.adoc
@@ -18,16 +18,16 @@ Adding marker files to `.openshift/markers` will have the following effects:
 |Marker |Effect
 
 |force_clean_build
-|Will remove all previous deps and start installing required deps from scratch
+|Will remove all previous dependencies and start installing required dependencies from scratch.
 
 |hot_deploy
-|Will prevent the apache process from being restarted during build/deployment
+|Will prevent the apache process from being restarted during build/deployment.
 
 |disable_auto_scaling
-|Will prevent scalable applications from scaling up or down according to application load.
+|Will prevent scalable applications from scaling up or down, according to application load.
 
 |use_composer
-|Will enable running composer install on each build automatically. See the link:https://getcomposer.org/[Composer].
+|Will enable running `composer install` on each build automatically. See the link:https://getcomposer.org/[Composer].
 
 |enable_public_server_status
 |Will enable server-status application path to be publicly available.


### PR DESCRIPTION
 - Adds consistent use of a dot `.` at the end of each sentence
 - Uses full word for `dependencies` instead of abbreviation
 - Makes `composer install` look like an actual command