### PR TITLE
Issue#370: 

### DIFF
--- a/lib/en/getting-started-debian-ubuntu.adoc
+++ b/lib/en/getting-started-debian-ubuntu.adoc
@@ -41,17 +41,15 @@ NOTE: The `sudo` command only works if the particular user is listed in the _sud
 
 [[client-tools-gem]]
 == Installing the Client Tools via Ruby gem
-Installing the client tools this way on Ubuntu or Debian requires sudoer or root access and comprises four steps:
+Installing the client tools this way on Ubuntu or Debian requires sudoer or root access and comprises three steps:
 
-*Step 1*: Install *_Ruby_*
+*Step 1*: Install *_Ruby_* with *_RubyGems_*
 
-*Step 2*: Install *_RubyGems_*
+*Step 2*: Install *_Git_*
 
-*Step 3*: Install *_Git_*
+*Step 3*: Install the client tools
 
-*Step 4*: Install the client tools
-
-=== Step 1: Install Ruby
+=== Step 1: Install Ruby with RubyGems
 
 From terminal, run the following command to install Ruby:
 [source]
@@ -66,15 +64,13 @@ $ ruby -e 'puts "Welcome to Ruby"'
 Welcome to Ruby
 ----
 
-=== Step 2: Install RubyGems
-
-Run the following command to install RubyGems:
+Rubygems are now part of the ruby package. However, with older Ubuntu repositories, you may need to run the following command to explicitly install RubyGems:
 [source]
 ----
 $ sudo apt-get install rubygems
 ----
 
-=== Step 3: Install Git
+=== Step 2: Install Git
 
 Run the following command to install Git version control:
 [source]
@@ -90,7 +86,7 @@ $ git --version
 
 This command returns the Git version number that was installed.
 
-=== Step 4: Install Client Tools
+=== Step 3: Install Client Tools
 
 When the required software has been successfully installed, run the following command to install the client tools:
 [source]


### PR DESCRIPTION
`rubygems` are now installed installed within `ruby-full`, `rubygems-integration` package does not seem to be required for OpenShift client tools.

Tested on brand new virtual machines Ubuntu 14.04 LTS and 15.10 (i.e. default apt sources for trusty and wily), not tested on Debian
Removed step 2 from getting started for the Debian/Ubuntu. 
Can be previewed here:
https://devcenter-jfiala.rhcloud.com/en/getting-started-debian-ubuntu.html#client-tools-gem

@suspect-zero, please review