### PR TITLE
Remove the documentation for the java8 tomcat marker

### DIFF
--- a/lib/en/tomcat-markers.adoc
+++ b/lib/en/tomcat-markers.adoc
@@ -32,8 +32,4 @@ Adding marker files to `.openshift/markers` will have the following effects:
 |`java7`
 |Will run Tomcat with Java7 if present. If no marker is present then the baseline Java version will be used (currently Java6)
 
-|`java8`
-|Will run Tomcat with Java8 if present. If no marker is present then the baseline Java version will be used (currently Java6)
-|===
-
 link:#top[Back to Top]


### PR DESCRIPTION
This marker was removed shortly after its addition due to java8 not being supported with jbossews-2.0. The marker was removed with commit:
   https://github.com/openshift/origin-server/commit/833c5ea1778cb9279ef53cdac99f3e879adee1d4