### PR TITLE
Add Node.js Markers page

### DIFF
--- a/lib/en/managing-markers.adoc
+++ b/lib/en/managing-markers.adoc
@@ -48,7 +48,7 @@ Below you can find links to markers available in various cartridges:
 
 link:jbossas-markers.html[JBoss AS markers] +
 link:jbosseap-markers.html[JBoss EAP markers] +
-link:node-js-project-structure.html#markers[Node.js markers] +
+link:node-js-markers.html[Node.js markers] +
 link:perl-overview.html#_markers[Perl markers] +
 link:php-markers.html[PHP markers] +
 link:python-markers.html[Python markers] +

--- a/lib/en/node-js-markers.adoc
+++ b/lib/en/node-js-markers.adoc
@@ -1,0 +1,37 @@
+---
+layout: nodejs
+category:
+breadcrumb: Languages
+parent_url: languages-overview.html
+nav_title: Markers
+nav_priority: 38
+meta_desc: Node.js - OpenShift Online PHP marker files
+---
+= Node.js Markers
+
+[float]
+= Node.js Markers
+Marker files can be used to customize various aspects of the Nodejs build and deployment process.
+
+Adding the following empty files to your project's `.openshift/markers` folder allows you to customize the runtime experience:
+
+[cols="1,3",options="header"]
+|===
+|Marker File | Effect
+
+|force_clean_build
+|Will remove all previous dependencies and start installing required dependencies from scratch.
+
+|use_npm
+|Initialize your application or service using `npm start` instead of `supervisor servername.js` (where `servername.js` is based on the value of your `package.json`'s `main` attribute).
+
+|NODEJS_VERSION
+|File with a version number will force that specific version to be run. E.g.: for running Node version 0.9.1, simply put `0.9.1` into this marker file.
+
+|hot_deploy
+|Push code updates without waiting for a full application restart. link:/en/managing-modifying-applications.html#_hot_deployment_build_details[This feature] is not available when the `use_npm` marker is enabled.
+
+|disable_auto_scaling
+|Will prevent scalable applications from scaling up or down, according to application load.
+
+|===

--- a/lib/en/node-js-project-structure.adoc
+++ b/lib/en/node-js-project-structure.adoc
@@ -3,14 +3,14 @@ layout: nodejs
 category:
 breadcrumb: Languages
 parent_url: languages-overview.html
-nav_title: Project Structure
+nav_title: Repository Layout
 nav_priority: 29
-meta_desc: Node.js Project Structure
+meta_desc: Node.js Project Structure Repository Layout
 ---
-= Node.js Project Structure
+= Node.js Repository Layout
 
 [float]
-= Node.js Project Structure
+= Node.js Repository Layout
 Nodejs applications should include the following basic project structure:
 
 [source]
@@ -19,9 +19,12 @@ server.js                The default server script name
 package.json             Npm package descriptor: dependency list, init config
 node_modules/            Locally bundled module dependencies (Recommended)
 .openshift/              OpenShift-specific files (Optional)
-    markers/             OpenShift configuration flags, see "Marker Files"
-    action_hooks/        Custom build scripts, see "Action Hooks"
+    markers/             OpenShift configuration flags, see the "Markers" list <1>
+    action_hooks/        Custom build scripts, see the "Action Hooks" documentation <2>
 ----
+
+<1> link:node-js-markers.html[Node.js marker files]
+<2> See the link:managing-action-hooks.html[action_hooks documentation] for detailed usage notes.
 
 [[server.js]]
 == `server.js`
@@ -60,29 +63,7 @@ Check the link:#markers[Markers] section for specifics on how OpenShift uses thi
 [[node_modules]]
 == `node_modules`
 
-Npm module dependencies are cached locally within this folder.  
-OpenShift can generate this folder's contents automatically by running `npm install` during your project's build process.  Tracking the contents of this folder with `git` can help make deployments easier to audit, and it allows OpenShift to use the cached modules to speed up your build process. 
+Npm module dependencies are cached locally within this folder.
+OpenShift can generate this folder's contents automatically by running `npm install` during your project's build process.  Tracking the contents of this folder with `git` can help make deployments easier to audit, and it allows OpenShift to use the cached modules to speed up your build process.
 
-=== `deplist.txt`
-This file was previously used to document an application's dependency list.  The standard `package.json` file should be used instead. See link:node-js-dependency-management.html[Dependency Management with NPM].
-
-[[markers]]
-== Marker Files
-Marker files can be used to customize various aspects of the Nodejs build and deployment process.
-
-Adding the following empty files to your project's `.openshift/markers` folder allows you to customize the runtime experience:
-
-[cols="1,3",options="header"]
-|===
-|Marker File | Effect
-|use_npm
-|Initialize your application or service using `npm start` instead of `supervisor servername.js` (where `servername.js` is based on the value of your `package.json`'s `main` attribute).
-|hot_deploy
-|Push code updates without waiting for a full application restart. link:/en/managing-modifying-applications.html#_hot_deployment_build_details[This feature] is not available when the `use_npm` marker is enabled.
-|===
-
-[[action_hooks]]
-== Action Hooks
-link:managing-action-hooks.html[OpenShift Action Hooks] are optional automation scripts that allow for additional customization during the application build and deployment process.
-
-See the link:managing-action-hooks.html[related action_hook documentation] for detailed usage notes.
+NOTE: The `deplist.txt` file was previously used to document an application's dependency list.  The standard `package.json` file should be used instead. See link:node-js-dependency-management.html[Dependency Management with NPM].


### PR DESCRIPTION
* add a dedicated Markers page for Node.js
* remove duplicate content from "Project Structure"
* add links to markers and action hooks on top (standard)
* rename "Project Structure" to "Repository Layout" (standard)
* transform the mention of `deplist.txt` into a note
* closes #432

Notes:
This change makes the Node.js section more consistent with other
Language sections. It is still using the "node-js-project-structure"
file (thus no redirect needed).

The changes can be previewed here:
https://devcenter-jfiala.rhcloud.com/en/nodejs-markers.html
https://devcenter-jfiala.rhcloud.com/en/node-js-project-structure.html

Signed-off-by: Jiri Fiala <jfiala@redhat.com>