### PR TITLE
wss SSL cert, scalable MySQL/phpMyAdmin

### DIFF
--- a/lib/en/addons-phpmyadmin.adoc
+++ b/lib/en/addons-phpmyadmin.adoc
@@ -17,14 +17,14 @@ phpMyAdmin is a free software tool written in PHP, intended to handle the admini
 
 
 == Installation
-phpMyAdmin can be installed using the following command:
+The phpMyAdmin add-on can be installed using the following command:
 [source,console]
 --
 $rhc cartridge add phpmyadmin -a <appname>
 --
 NOTE: You must have one of the MySQL cartridges installed for this add-on to be installed.
 
-NOTE: You can not install this add-on into a scaled application.
+TIP: You can not install this add-on into a *scalable* application. Consider link:managing-port-forwarding.html[port forwarding] in order to use a local database management software of your choice.
 
 [source,console]
 --

--- a/lib/en/databases-mysql.adoc
+++ b/lib/en/databases-mysql.adoc
@@ -91,6 +91,6 @@ http://MyApp-MyDomain.rhcloud.com/
 
 [[phpmyadmin]]
 === phpMyAdmin
-The `phpmyadmin` cartridge provides http://www.phpmyadmin.net[phpMyAdmin] on OpenShift. In order to add this cartridge to an application, the link:#top[MySQL] cartridge must already be present. Once installed, phpMyAdmin can be used by navigating to http://_app_-_domain_.rhcloud.com/phpmyadmin with the MySQL login credentials.
+The link:addons-phpmyadmin.html[*phpmyadmin* cartridge] provides http://www.phpmyadmin.net[phpMyAdmin] on OpenShift. In order to add this cartridge to an application, the link:#top[MySQL] cartridge must already be present. Once installed, phpMyAdmin can be used by navigating to http://_app_-_domain_.rhcloud.com/phpmyadmin with the MySQL login credentials.
 
 link:#top[Back to Top]

--- a/lib/en/managing-domains-ssl.adoc
+++ b/lib/en/managing-domains-ssl.adoc
@@ -120,9 +120,9 @@ link:#top[Back to Top]
 === Using a Custom SSL Certificate
 OpenShift includes support for link:http://en.wikipedia.org/wiki/Server_Name_Indication[Server Name Identification], which improves support for link:http://en.wikipedia.org/wiki/Server_Name_Indication#How_SNI_fixes_the_problem[TLS] by sending your OpenShift-configured domain alias as a part of the handshake.
 
-You can always take advantage of our **.rhcloud.com* wildcard certificate in order to securely connect to any application via it's original, OpenShift-provided hostname URL.
-
 Support for enabling *HTTPS* connections to custom, aliased hostnames is available for users of https://www.openshift.com/products/pricing[OpenShift Online's premium plans].
+
+If you are not using one of the premium plans, or if you are connecting to your app using link:managing-port-binding-routing.html[secure web sockets], you can always take advantage of our **.rhcloud.com* wildcard certificate in order to securely connect to any application via it's original, OpenShift-provided hostname URL.
 
 If you are still getting by on the link:https://www.openshift.com/products/pricing[Free Plan], you'll see a warning message at the top of your application's SSL configuration area. Upgrading to the Bronze or Silver plan adds support for providing your own SSL cert.
 

--- a/lib/en/managing-port-binding-routing.adoc
+++ b/lib/en/managing-port-binding-routing.adoc
@@ -15,4 +15,6 @@ meta_desc: How OpenShift routes HTTP/HTTPS/WS/WSS requests to your application a
 [.lead]
 image::port-binding-routing.png[Port Binding and Routing]
 
-If you are building a cartridge and trying to bind to internal ports, please see the link:https://docs.openshift.org/origin-m4/oo_cartridge_developers_guide.html#endpoints[Cartridge Developers Guide].
+TIP: If you are building a cartridge and trying to bind to internal ports, please see the link:https://docs.openshift.org/origin-m4/oo_cartridge_developers_guide.html#endpoints[Cartridge Developers Guide].
+
+NOTE: link:managing-domains-ssl.html#using-a-custom-ssl-certificate[Custom SSL certificates] are not available for wss. Use the default **.rhcloud.com* certificate with secure web sockets.


### PR DESCRIPTION
* add a note about custom SSL certficates not available with wss to:
    - Port binding and routing
    - Domains and SSL
* link port forwarding from the phpMyAdmin page (scalable note)
* link phpMyAdmin addon from the MySQL page
* closes #437

The mentioned changes can be previewed here:
https://devcenter-jfiala.rhcloud.com/en/managing-port-binding-routing.html
https://devcenter-jfiala.rhcloud.com/en/managing-domains-ssl.html#using-a-custom-ssl-certificate
https://devcenter-jfiala.rhcloud.com/en/addons-phpmyadmin.html
https://devcenter-jfiala.rhcloud.com/en/databases-mysql.html#phpmyadmin

Signed-off-by: Jiri Fiala <jfiala@redhat.com>