### PR TITLE
docs: add link to rfc1123

### DIFF
--- a/source/managing-your-applications/domains-ssl.adoc
+++ b/source/managing-your-applications/domains-ssl.adoc
@@ -72,7 +72,7 @@ Clicking this link will open up the new hostname configuration page:
 
 image::overview-platform-features-12.png[Adding a domain alias part 2]
 
-Here you can enter the domain name that you would like to associate with your application. The above example uses _\http://parks.ryanjarvinen.com/_.
+Here you can enter a link:https://tools.ietf.org/html/rfc1123#page-13[valid] domain name that you would like to associate with your application. The above example uses _\http://parks.ryanjarvinen.com/_.
 
 Configuring your application to be available on a subdomain is generally easier.
 


### PR DESCRIPTION
* Adds a link to RFC1123 which documents valid hostname/subdomain
  syntax.
  This change follows Bugzilla #1329915 [1], PR #6384 on
  openshift/origin-server/#6384 [2] and issue #451 on
  openshift/devcenter/#451 [3]. (closes #451)

[1] - https://bugzilla.redhat.com/show_bug.cgi?id=1329915
[2] - https://github.com/openshift/origin-server/pull/6384
[3] - https://github.com/openshift/devcenter/issues/451