### PR TITLE
Point to RubyInstaller downloads instead of archives

### DIFF
--- a/source/getting-started/windows.adoc
+++ b/source/getting-started/windows.adoc
@@ -44,7 +44,7 @@ link:http://rubyinstaller.org[RubyInstaller] provides the best experience for in
 
 NOTE: The Client Tools are known to work well with Ruby versions *1.9.3* and *2.0.0* on Windows, based on the community feedback. We recommend downloading and installing one of those versions.
 
-Download one of the preferred versions from the link:http://rubyinstaller.org/downloads/archives/[RubyInstaller archives] and launch it.
+Download one of the preferred versions from the link:http://rubyinstaller.org/downloads/[RubyInstaller downloads] and launch it.
 
 IMPORTANT: During the installation you can accept all of the defaults, but it is mandatory that you select the *Add Ruby executables to your PATH* check box in order to run Ruby from the command line (see image below).
 


### PR DESCRIPTION
One of the recommended versions (2.0.0) is available on the download page, but the archive page does not have the most recent security patches available. I changed the link to point to the download page instead of the archive page. Archives can still be reached from the download page with a single click if the user prefers version 1.9.3.