### PR TITLE
Fixed typo in navbar for old doc version

### DIFF
--- a/source/layouts/_navbar.erb
+++ b/source/layouts/_navbar.erb
@@ -1,6 +1,6 @@
 <div class='v2-warning' style='display: none;'>
   <a href="https://docs.openshift.com/">PLEASE NOTE: These documents apply to OpenShift Online (v2)<br>
-  <small>If you are using OpenShift 3.X, you should refer to the docs that go with that version, available at docs.openshfit.com.</small></a>
+  <small>If you are using OpenShift 3.X, you should refer to the docs that go with that version, available at docs.openshift.com.</small></a>
   <a href="#dismiss" id='v2-warning-dismiss' style='float: right;'>X</a>
 </div>
 


### PR DESCRIPTION
Fixed typo in the hostname mentioned in the navbar