### PR TITLE
faq: update Customer Service contact

### DIFF
--- a/source/faq/account.adoc
+++ b/source/faq/account.adoc
@@ -40,12 +40,10 @@ If you are an existing user, the easiest way to upgrade your account is to go li
 
 You can also manage your plan by going to your link:https://openshift.redhat.com/app/console/settings[Account Settings] page and clicking the *Upgrade your account* link at the top of the page.
 
-If you are a new user, you can sign up for the plan you want directly from the link:https://www.openshift.com/pricing[Pricing Page].
-
 link:#top[Back to Top]
 
 === Can I pay for my Bronze or Silver Plan with Paypal?
-Currently OpenShift Online only accepts credit card payments from the US, Canada, and Europe. Please see the link:https://www.openshift.com/pricing[Pricing Page] for more details.
+Currently OpenShift Online only accepts credit card payments from the US, Canada, and Europe.
 
 link:#top[Back to Top]
 
@@ -111,7 +109,7 @@ link:#top[Back to Top]
 === How do I indicate that I am exempt from taxes?
 To qualify for tax exempt status you must submit a certificate to Red Hat. Upon receipt of your certificate we will refund all previously paid taxes to your credit card.
 
-To begin the process, please email customerservice@redhat.com.
+To begin the process, please link:https://access.redhat.com/support/contact/customerService/[contact Customer Service].
 
 link:#top[Back to Top]
 

--- a/source/index.adoc
+++ b/source/index.adoc
@@ -37,11 +37,6 @@ JBoss Developer Studio, with its Eclipse Based integrated development environmen
 
 link:/getting-started/installing-jboss-studio.html[-> Install and Use JBoss Developer Studio]
 
-== Pricing and Premium Features
-OpenShift Online currently offers several options to developers, including a pretty generous free tier. Please visit our link:https://www.openshift.com/products/pricing[pricing page] for more information.
-
-Interested in learning more about OpenShift's premium features? Visit our link:/overview/platform-features.html[features guide] for more information.
-
 == Get Started with OpenShift Online
 Ready to launch your big idea on OpenShift? link:/getting-started/index.html[Get started] now!
 

--- a/source/languages/nodejs/example-meanstack.adoc
+++ b/source/languages/nodejs/example-meanstack.adoc
@@ -129,11 +129,11 @@ Or, in the OpenShift web console:
 
 image:https://www.openshift.com/sites/default/files/scaling_web.png[OpenShift web console scaling]
 
-OpenShift Online's link:https://www.openshift.com/products/pricing[free plan includes support for running up to three containers concurrently].  You can increase your account's capacity by link:https://www.openshift.com/products/pricing[upgrading to OpenShift Online's Silver or Bronze plans], or by setting up link:http://openshift.com/[your own open source cloud].
+OpenShift Online's free plan includes support for running up to three containers concurrently. You can increase your account's capacity by link:https://openshift.redhat.com/app/account/plan[upgrading to OpenShift Online's Silver or Bronze plans].
 
 [[next-steps]]
 === Next Steps
 1. link:http://twitter.com/OpenShift[Tell us] about your experiences with MEANStack on OpenShift
 2. Find out how easy it is to link:https://www.openshift.com/blogs/domain-names-and-ssl-in-the-openshift-web-console[assign a custom domain name to your applications]
-3. Upgrade to OpenShift Online's link:https://www.openshift.com/products/pricing[Bronze plan] to access link:https://www.openshift.com/products/pricing[additional scaling capacity, and the ability to add your own custom SSL certificates]
+3. Upgrade to OpenShift Online's link:https://openshift.redhat.com/app/account/plan[Bronze plan] to access additional scaling capacity, and the ability to add your own custom SSL certificates
 4. Help us find your questions on StackOverflow by using the link:http://stackoverflow.com/questions/tagged/openshift[OpenShift] and link:http://stackoverflow.com/questions/tagged/mean-stack[MEAN Stack] tags

--- a/source/managing-your-applications/domains-ssl.adoc
+++ b/source/managing-your-applications/domains-ssl.adoc
@@ -120,11 +120,11 @@ link:#top[Back to Top]
 === Using a Custom SSL Certificate
 OpenShift includes support for link:http://en.wikipedia.org/wiki/Server_Name_Indication[Server Name Identification], which improves support for link:http://en.wikipedia.org/wiki/Server_Name_Indication#How_SNI_fixes_the_problem[TLS] by sending your OpenShift-configured domain alias as a part of the handshake.
 
-Support for enabling *HTTPS* connections to custom, aliased hostnames is available for users of https://www.openshift.com/products/pricing[OpenShift Online's premium plans].
+Support for enabling *HTTPS* connections to custom, aliased hostnames is available for users of link:https://openshift.redhat.com/app/account/plan[OpenShift Online's premium plans].
 
 If you are not using one of the premium plans, or if you are connecting to your app using link:managing-port-binding-routing.html[secure web sockets], you can always take advantage of our **.rhcloud.com* wildcard certificate in order to securely connect to any application via it's original, OpenShift-provided hostname URL.
 
-If you are still getting by on the link:https://www.openshift.com/products/pricing[Free Plan], you'll see a warning message at the top of your application's SSL configuration area. Upgrading to the Bronze or Silver plan adds support for providing your own SSL cert.
+If you are still getting by on the Free Plan, you'll see a warning message at the top of your application's SSL configuration area. Upgrading to the Bronze or Silver plan adds support for providing your own SSL cert.
 
 ==== Web Console
 

--- a/source/managing-your-applications/idling.adoc
+++ b/source/managing-your-applications/idling.adoc
@@ -26,7 +26,7 @@ No, we do not currently have a mechanism to send out notifications when your app
 == How do I keep my application from idling?
 There are two ways to keep your applications from idling:
 
-* Upgrade to a premium plan.  Applications running on premium plans are idled after prolonged period of no requests flowing in.  See the link:https://www.openshift.com/products/pricing/plan-comparison[Plan Comparison] page for more information.
+* link:https://openshift.redhat.com/app/account/plan[Upgrade to a premium plan].  Applications running on premium plans are idled after prolonged period of no requests flowing in.
 * Make a popular application that gets lots of traffic.  Make sure that your application uses standard SEO practices and provides unique and useful content.
 
 link:#top[Back to Top]

--- a/source/managing-your-applications/resource-management.adoc
+++ b/source/managing-your-applications/resource-management.adoc
@@ -23,7 +23,7 @@ link:#additional-gear-storage[Additional Gear Storage] +
 === Additonal Gear Sizes
 OpenShift currently offers four gear sizes that can be selected at the time an application is created. For all OpenShift users, 3 small gears are available for free. Premium plan customers have access to larger gear sizes and to more gears, allowing the creation of more applications and the ability to scale those applications based on usage.
 
-The following gear prices are in USD. For CAD or EUR pricing, please refer to the plans and https://www.openshift.com/pricing[pricing page].
+The following gear prices are in USD.
 
 [cols=".<2,.<4,.<3", width='60%']
 |===

--- a/source/overview/platform-features.adoc
+++ b/source/overview/platform-features.adoc
@@ -15,9 +15,7 @@ description: OpenShift Online offers many powerful application management option
 [.lead]
 OpenShift Online offers many powerful application management options, some of which are only available on the premium Bronze and Silver plans. The following series of quick guides is intended to help you become familiar with these features.
 
-IMPORTANT: OpenShift Online premium plan support is currently available to customers with a billing address in the *United States*, *Canada*, *Russia*, *Israel*, or *Europe* (*EU member states*, *Iceland*, *Norway*, and *Switzerland*). link:https://www.openshift.com/dedicated[OpenShift Dedicated] is available for purchase worldwide.
-
-If you would like to see the OpenShift Online premium plans extended to your country, please let us know by filling out the request form https://www.openshift.com/products/pricing/geo-request-form[here].
+IMPORTANT: OpenShift Online Current Gen (v2) premium plan support is currently available to customers with a billing address in the *United States*, *Canada*, *Russia*, *Israel*, or *Europe* (*EU member states*, *Iceland*, *Norway*, and *Switzerland*). link:https://www.openshift.com/dedicated[OpenShift Dedicated] is available for purchase worldwide.
 
 == Feature List
 link:#regions-and-zones[Region and Zone Management] +


### PR DESCRIPTION
As the "legacy" pricing page is not available, the obsolete references (now pointing to v3 pricing page with only the *Starter* plan being there) were removed or replaced with a direct link to the console for users to upgrade their plan.

----

* replaces the customer service contact email with a whole list of
  available customer service worldwide contacts
* removes obsolete pricing links or replaces them with account upgrade
  link, where suitable

Signed-off-by: Jiri Fiala <jfiala@redhat.com>