### PR TITLE
layouts: permanent v2 banner

### DIFF
--- a/source/layouts/_navbar.erb
+++ b/source/layouts/_navbar.erb
@@ -1,7 +1,13 @@
-<div class='v2-warning' style='display: none;'>
-  <a href="https://docs.openshift.com/">PLEASE NOTE: These documents apply to OpenShift Online (v2)<br>
-  <small>If you are using OpenShift 3.X, you should refer to the docs that go with that version, available at docs.openshift.com.</small></a>
-  <a href="#dismiss" id='v2-warning-dismiss' style='float: right;'>X</a>
+<div class='v2-warning' onclick="window.location='https://docs.openshift.com/';">
+  <div>
+    <i class="fa fa-info-circle fa-3x" aria-hidden="true"></i>
+  </div>
+  <div>
+    Please note that these documents apply to OpenShift Online v2 only<span class="longer-v2-notice"> (accounts created before August 1st, 2016)</span>.<br>
+    <a href="https://docs.openshift.com/">
+      <small>If you are using one of the OpenShift 3 products, please refer to <span class="longer-v2-notice">documents available at </span>docs.openshift.com.</small>
+    </a>
+  </div>
 </div>
 
 <div class="navbar navbar-default navbar-openshift" role="navigation">
@@ -326,7 +332,7 @@
     <a class="navbar-brand" href="/"></a>
   </div>
   <div class="navbar-collapse collapse">
-    
+
     <ul class="nav navbar-nav navbar-right">
       <li class="hidden-xs dropdown">
         <a href="#" class="dropdown-toggle nav-log-in" data-toggle="dropdown">

--- a/source/layouts/base.erb
+++ b/source/layouts/base.erb
@@ -28,18 +28,6 @@
   <!-- IE8 requires jQuery v1.x -->
   <%= javascript_include_tag "#{openshift_assets}/modernizr.js" %>
   <%= javascript_include_tag "#{openshift_assets}/subdomain.js" %>
-  <script type="text/javascript">
-    $(document).ready(function(){
-      if (localStorage.getItem('v2warning') !== 'true') {
-        $('.v2-warning').show();
-      }
-      $('#v2-warning-dismiss').on('click',function(e){
-        e.preventDefault();
-        localStorage.setItem('v2warning','true');
-        $('.v2-warning').hide();
-      });
-    });
-  </script>
 </head>
 <body class="<%= page_classes %> online">
 <%= partial "layouts/tracking" %>

--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -28,18 +28,6 @@
     <!-- IE8 requires jQuery v1.x -->
     <%= javascript_include_tag "#{openshift_assets}/modernizr.js" %>
     <%= javascript_include_tag "#{openshift_assets}/subdomain.js" %>
-    <script type="text/javascript">
-      $(document).ready(function(){
-        if (localStorage.getItem('v2warning') !== 'true') {
-          $('.v2-warning').show();
-        }
-        $('#v2-warning-dismiss').on('click',function(e){
-          e.preventDefault();
-          localStorage.setItem('v2warning','true');
-          $('.v2-warning').hide();
-        });
-      });
-    </script>
 </head>
 <body class="<%= page_classes %> online">
     <%= partial "layouts/tracking" %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -30,18 +30,6 @@
   <%= javascript_include_tag "#{openshift_assets}/subdomain.js" %>
   <%= javascript_include_tag "navtree.js" %>
   <%= javascript_include_tag "fixheight.js" %>
-  <script type="text/javascript">
-    $(document).ready(function(){
-      if (localStorage.getItem('v2warning') !== 'true') {
-        $('.v2-warning').show();
-      }
-      $('#v2-warning-dismiss').on('click',function(e){
-        e.preventDefault();
-        localStorage.setItem('v2warning','true');
-        $('.v2-warning').hide();
-      });
-    });
-  </script>
 </head>
 <body class="online">
 <%= partial "layouts/tracking" %>
@@ -77,7 +65,7 @@
         <input type="text" autofocus="" autocomplete="off" tabindex="1" placeholder="Search" class="navbar-search-query form-control" id="cse-search-input" name="query">
         <button value="Search" class="btn btn-default fa fa-search" type="submit"></button>
       </form>
-      
+
       <% if current_page.path.split(File::SEPARATOR).count == 1 %>
         <ul class="nav nav-sidebar">
           <%= build_navtree() %>
@@ -91,7 +79,7 @@
           <li><a href='/help.html'>Get Help <span class="fa fa-question-circle small"></span></a></li>
         </ul>
       <% end %>
-      
+
       <div id="google_translate_element"></div><script type="text/javascript">
 function googleTranslateElementInit() {
   new google.translate.TranslateElement({pageLanguage: 'en'}, 'google_translate_element');

--- a/source/stylesheets/devcenter.css
+++ b/source/stylesheets/devcenter.css
@@ -1259,11 +1259,22 @@ h3 {
     padding: 15px 20px;
     text-align: center;
 }
+.v2-warning > div {
+  display: inline-block;
+  margin-left: 15px;
+}
+@media screen and (max-width: 520px) {
+  /* make the warning shorter for smaller viewports */
+  .v2-warning .longer-v2-notice {
+    display: none;
+  }
+}
 .v2-warning a {
   color:#fff;
 }
 .v2-warning:hover {
     background-color: #0269c2;
     color: #fff;
+    cursor: pointer;
     text-decoration: none;
 }


### PR DESCRIPTION
* permanently displays the v2 top info banner
* updates the text slighly
* still leads to docs.openshift.com, the whole div is clickable

Signed-off-by: Jiri Fiala <jfiala@redhat.com>